### PR TITLE
Input assumptions for RNG

### DIFF
--- a/brng/brng.go
+++ b/brng/brng.go
@@ -225,6 +225,8 @@ func (brnger *BRNGer) TransitionSlice(slice table.Slice) (shamir.VerifiableShare
 	if faults != nil {
 		brnger.state = Error
 
+		// TODO: This is incorrect; even if there are fualts in the shares, we
+		// still need to return the commitment.
 		return nil, nil, faults
 	}
 

--- a/rng/rng_test.go
+++ b/rng/rng_test.go
@@ -152,7 +152,7 @@ var _ = Describe("RNG", func() {
 					break
 				}
 
-				setsOfSharesByPlayer[index] = []shamir.VerifiableShares{}
+				setsOfSharesByPlayer[index] = nil
 				idleCount++
 			}
 

--- a/rng/rngutil/machine.go
+++ b/rng/rngutil/machine.go
@@ -37,7 +37,8 @@ func NewRngMachine(
 	ownSetsOfShares []shamir.VerifiableShares,
 	ownSetsOfCommitments [][]shamir.Commitment,
 ) RngMachine {
-	rnger, directedOpenings, commitments := rng.New(index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero)
+	rnger, directedOpenings, commitments :=
+		rng.New(index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero)
 
 	return RngMachine{
 		id:      id,

--- a/rng/transition_test.go
+++ b/rng/transition_test.go
@@ -152,9 +152,9 @@ var _ = Describe("RNG/RZG state transitions", func() {
 					}
 				})
 
-				Specify("empty sets of shares and valid commitments -> WaitingOpen", func() {
+				Specify("nil sets of shares and valid commitments -> WaitingOpen", func() {
 					_, setsOfCommitments := rngutil.BRNGOutputBatch(index, b, c, h)
-					_, directedOpenings, _ := rng.New(index, indices, h, []shamir.VerifiableShares{}, setsOfCommitments, isZero)
+					_, directedOpenings, _ := rng.New(index, indices, h, nil, setsOfCommitments, isZero)
 
 					// With empty shares, the shares for the directed opens
 					// should not be computed.
@@ -166,18 +166,11 @@ var _ = Describe("RNG/RZG state transitions", func() {
 					}
 				})
 
-				Specify("shares with incorrect batch size -> WaitingOpen", func() {
+				Specify("shares with incorrect batch size -> panic", func() {
 					setsOfShares, setsOfCommitments := rngutil.BRNGOutputBatch(index, b, c, h)
-					_, directedOpenings, _ := rng.New(index, indices, h, setsOfShares[1:], setsOfCommitments, isZero)
-
-					// With invalid shares, the shares for the directed opens
-					// should not be computed.
-					for _, j := range indices {
-						shares := directedOpenings[j]
-						for _, share := range shares {
-							Expect(share).To(Equal(shamir.VerifiableShares{}))
-						}
-					}
+					Expect(func() {
+						rng.New(index, indices, h, setsOfShares[1:], setsOfCommitments, isZero)
+					}).To(Panic())
 				})
 
 				Specify("shares with incorrect threshold size -> panic", func() {


### PR DESCRIPTION
This PR addresses the fact that the inputs to RNG were not handled as per the specification: it should be the case that if the given shares are not `nil`, then they should be assumed to be correct (valid w.r.t. the commit, have the right dimensions, etc.).