### PR TITLE
BRNG renaming/cleanup

### DIFF
--- a/brng/brngutil/machine.go
+++ b/brng/brngutil/machine.go
@@ -89,7 +89,7 @@ func (pm PlayerMachine) InitialMessages() []mpcutil.Message {
 // Handle implements the Machine interface.
 func (pm *PlayerMachine) Handle(msg mpcutil.Message) []mpcutil.Message {
 	cmsg := msg.(*ConsensusMessage)
-	shares, commitments, _ := pm.brnger.TransitionSlice(cmsg.slice)
+	shares, commitments, _ := pm.brnger.HandleSlice(cmsg.slice)
 	pm.SetOutput(shares, commitments)
 	return nil
 }

--- a/brng/marshal.go
+++ b/brng/marshal.go
@@ -1,0 +1,49 @@
+package brng
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+
+	"github.com/renproject/secp256k1"
+	"github.com/renproject/surge"
+)
+
+// Generate implements the quick.Generator interface.
+func (brnger BRNGer) Generate(_ *rand.Rand, _ int) reflect.Value {
+	batchSize := rand.Uint32()
+	h := secp256k1.RandomPoint()
+	return reflect.ValueOf(BRNGer{batchSize, h})
+}
+
+// SizeHint implements the surge.SizeHinter interface.
+func (brnger BRNGer) SizeHint() int {
+	return surge.SizeHint(brnger.batchSize) +
+		brnger.h.SizeHint()
+}
+
+// Marshal implements the surge.Marshaler interface.
+func (brnger BRNGer) Marshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := surge.MarshalU32(uint32(brnger.batchSize), buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("marshaling batchSize: %v", err)
+	}
+	buf, rem, err = brnger.h.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("marshaling h: %v", err)
+	}
+	return buf, rem, nil
+}
+
+// Unmarshal implements the surge.Unmarshaler interface.
+func (brnger *BRNGer) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := surge.UnmarshalU32(&brnger.batchSize, buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("unmarshaling batchSize: %v", err)
+	}
+	buf, rem, err = brnger.h.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("unmarshaling h: %v", err)
+	}
+	return buf, rem, nil
+}


### PR DESCRIPTION
This PR renames a BRNG function name, moves marshalling into its own file, and removes an unneeded function.