### PR TITLE
Threshold check in RNG

### DIFF
--- a/mulopen/mulopen.go
+++ b/mulopen/mulopen.go
@@ -120,8 +120,10 @@ func New(
 
 	// Handle own message immediately.
 	output, err := mulopener.HandleShareBatch(messageBatch)
-	if output != nil || err != nil {
+	if output != nil {
 		panic("unexpected result handling own message")
+	} else if err != nil {
+		panic(fmt.Sprintf("unexpected result handling own message: %v", err))
 	}
 
 	return mulopener, messageBatch

--- a/rng/rng.go
+++ b/rng/rng.go
@@ -57,6 +57,10 @@ func New(
 	if k <= 1 {
 		panic(fmt.Sprintf("k must be greater than 1, got: %v", k))
 	}
+	threshold := brngCommitmentBatch[0][0].Len()
+	if threshold < 2 {
+		panic(fmt.Sprintf("threshold must be greater than 1, got: %v", threshold))
+	}
 
 	var requiredBrngBatchSize int
 	if isZero {
@@ -72,10 +76,10 @@ func New(
 			panic("invalid commitment dimensions")
 		}
 		for _, commitment := range commitments {
-			if commitment.Len() != int(k) {
+			if commitment.Len() != threshold {
 				panic(fmt.Sprintf(
 					"inconsistent commitment threshold: expected %v, got %v",
-					k, commitment.Len(),
+					threshold, commitment.Len(),
 				))
 			}
 		}

--- a/rng/rngutil/testutil.go
+++ b/rng/rngutil/testutil.go
@@ -153,7 +153,7 @@ func BRNGOutputFull(
 func RNGSharesBatch(
 	indices []secp256k1.Fn,
 	index secp256k1.Fn,
-	b, k int,
+	b, k, threshold int,
 	h secp256k1.Point,
 	isZero bool,
 ) (
@@ -173,7 +173,7 @@ func RNGSharesBatch(
 
 	var rngShares shamir.VerifiableShares
 	for i := 0; i < b; i++ {
-		brngShares[i], brngComs[i], rngShares, coms[i] = RNGShares(indices, index, k, h, isZero)
+		brngShares[i], brngComs[i], rngShares, coms[i] = RNGShares(indices, index, k, threshold, h, isZero)
 
 		for j, share := range rngShares {
 			shares[indices[j]][i] = share
@@ -190,7 +190,7 @@ func RNGSharesBatch(
 func RNGShares(
 	indices []secp256k1.Fn,
 	index secp256k1.Fn,
-	k int,
+	k, threshold int,
 	h secp256k1.Point,
 	isZero bool,
 ) (shamir.VerifiableShares, []shamir.Commitment, shamir.VerifiableShares, shamir.Commitment) {
@@ -198,9 +198,9 @@ func RNGShares(
 	var coefSharesTrans []shamir.VerifiableShares
 	var coefComms []shamir.Commitment
 	if isZero {
-		coefSharesTrans, coefComms = BRNGOutputFull(indices, k-1, k, h)
+		coefSharesTrans, coefComms = BRNGOutputFull(indices, threshold-1, k, h)
 	} else {
-		coefSharesTrans, coefComms = BRNGOutputFull(indices, k, k, h)
+		coefSharesTrans, coefComms = BRNGOutputFull(indices, threshold, k, h)
 	}
 
 	com := compute.ShareCommitment(index, coefComms)

--- a/rng/transition_test.go
+++ b/rng/transition_test.go
@@ -39,10 +39,10 @@ var _ = Describe("RNG/RZG state transitions", func() {
 		// Batch size
 		b := 3 + rand.Intn(3)
 
-		// Shamir secret sharing threshold
+		// Threshold of RNG outputs
 		k := 3 + rand.Intn(n-3)
 
-		var c int
+		c := 3 + rand.Intn(n-3)
 		if isZero {
 			c = k - 1
 		} else {
@@ -79,9 +79,9 @@ var _ = Describe("RNG/RZG state transitions", func() {
 			})
 
 			It("should correctly compute the shares and commitments", func() {
-				_, indices, index, b, _, k, h := RandomTestParameters(isZero)
+				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
 				ownSetsOfShares, ownSetsOfCommitments, openingsByPlayer, _ :=
-					rngutil.RNGSharesBatch(indices, index, b, k, h, isZero)
+					rngutil.RNGSharesBatch(indices, index, b, k, c, h, isZero)
 				_, directedOpenings, _ := rng.New(
 					index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero,
 				)
@@ -95,9 +95,9 @@ var _ = Describe("RNG/RZG state transitions", func() {
 
 		Context("handling share batches", func() {
 			Specify("invalid share batches should return an error", func() {
-				_, indices, index, b, _, k, h := RandomTestParameters(isZero)
+				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
 				ownSetsOfShares, ownSetsOfCommitments, openingsByPlayer, _ :=
-					rngutil.RNGSharesBatch(indices, index, b, k, h, isZero)
+					rngutil.RNGSharesBatch(indices, index, b, k, c, h, isZero)
 				rnger, _, _ := rng.New(index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero)
 
 				// Pick an index other than our own.
@@ -117,9 +117,9 @@ var _ = Describe("RNG/RZG state transitions", func() {
 			})
 
 			Specify("upon receiving the kth valid share batch, the secrets should be reconstructed", func() {
-				_, indices, index, b, _, k, h := RandomTestParameters(isZero)
+				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
 				ownSetsOfShares, ownSetsOfCommitments, openingsByPlayer, _ :=
-					rngutil.RNGSharesBatch(indices, index, b, k, h, isZero)
+					rngutil.RNGSharesBatch(indices, index, b, k, c, h, isZero)
 				rnger, _, _ := rng.New(index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero)
 
 				// The own player's openings have already been processed.
@@ -143,9 +143,9 @@ var _ = Describe("RNG/RZG state transitions", func() {
 			})
 
 			It("the reconstructed secrets should be valid with respect to the commitments", func() {
-				_, indices, index, b, _, k, h := RandomTestParameters(isZero)
+				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
 				ownSetsOfShares, ownSetsOfCommitments, openingsByPlayer, _ :=
-					rngutil.RNGSharesBatch(indices, index, b, k, h, isZero)
+					rngutil.RNGSharesBatch(indices, index, b, k, c, h, isZero)
 				rnger, _, commitments := rng.New(
 					index, indices, h, ownSetsOfShares, ownSetsOfCommitments, isZero,
 				)

--- a/rng/transition_test.go
+++ b/rng/transition_test.go
@@ -185,7 +185,7 @@ var _ = Describe("RNG/RZG state transitions", func() {
 				}).To(Panic())
 			})
 
-			Specify("too small commitment threshold (k)", func() {
+			Specify("too small output threshold (k)", func() {
 				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
 				brngShareBatch, brngCommitmentBatch := rngutil.BRNGOutputBatch(index, b, c, k, h)
 				// For RNG, the number of coefficients that are specified needs
@@ -225,8 +225,12 @@ var _ = Describe("RNG/RZG state transitions", func() {
 
 			Specify("inconsistent commitment dimensions (threshold)", func() {
 				_, indices, index, b, c, k, h := RandomTestParameters(isZero)
+				// Having a batch size of at least 2 ensures we can test this condition.
+				if b == 1 {
+					b++
+				}
 				brngShareBatch, brngCommitmentBatch := rngutil.BRNGOutputBatch(index, b, c, k, h)
-				brngCommitmentBatch[0][0] = shamir.Commitment{}
+				brngCommitmentBatch[1][0] = shamir.Commitment{}
 				Expect(func() {
 					rng.New(index, indices, h, brngShareBatch, brngCommitmentBatch, isZero)
 				}).To(Panic())


### PR DESCRIPTION
This PR resolves #42.

The change required for the RNG code is small. Tests are updated to check the new panic case, and to check that the RNG state machine still works correctly when using independent RNG and BRNG thresholds.